### PR TITLE
Fix Bugs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-slim
 
-LABEL repository="https://github.com/bitprj/push-subdir"
+LABEL repository="https://github.com/emsesc/push-subdir"
 LABEL homepage="https://github.com/bitprj/push-subdir"
 LABEL maintainer="Daniel Kim <daniel@bitproject.org>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-slim
 
-LABEL repository="https://github.com/emsesc/push-subdir"
+LABEL repository="https://github.com/bitprj/push-subdir"
 LABEL homepage="https://github.com/bitprj/push-subdir"
 LABEL maintainer="Daniel Kim <daniel@bitproject.org>"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ for folder in $FOLDER/*; do
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
-  # cp -r $BASE/$folder/. .
+  cp -r $BASE/$folder/. ./$folder
 
 
   # Commit if there is anything to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ for folder in $FOLDER/*; do
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+  mkdir -p ./$folder
   cp -r $BASE/$folder/. ./$folder
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ for folder in $FOLDER/*; do
 
   # clone, delete files in the clone, and copy (new) files over
   # this handles file deletions, additions, and changes seamlessly
-  git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR # &> /dev/null
+  git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   mkdir -p ./$foldername
@@ -46,6 +46,7 @@ for folder in $FOLDER/*; do
   else
     echo "  No changes, skipping $BASE/$folder/"
   fi
-
+  
+  rmdir -r $CLONE_DIR
   cd $BASE
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ for folder in $FOLDER/*; do
   # clone, delete files in the clone, and copy (new) files over
   # this handles file deletions, additions, and changes seamlessly
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
+  echo "  Attempting to clone to $CLONE_DIR"
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   mkdir -p ./$foldername

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ for folder in $FOLDER/*; do
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   mkdir -p ./$foldername
   cp -r $BASE/$folder/. ./$foldername
+  echo "  Copied files to $foldername"
 
 
   # Commit if there is anything to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,7 @@ for folder in $FOLDER/*; do
 
   # clone, delete files in the clone, and copy (new) files over
   # this handles file deletions, additions, and changes seamlessly
-  git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
-  echo "  Attempting to clone to $CLONE_DIR"
+  git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR # &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   mkdir -p ./$foldername

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ for folder in $FOLDER/*; do
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
-  cp -r $BASE/$folder/. .
+  # cp -r $BASE/$folder/. .
 
 
   # Commit if there is anything to
@@ -40,7 +40,7 @@ for folder in $FOLDER/*; do
     git push origin $BRANCH_NAME
     echo  "  Completed $REPO_NAME"
   else
-    echo "  No changes, skipping $REPO_NAME"
+    echo "  No changes, skipping $BASE/$folder/"
   fi
 
   cd $BASE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ for folder in $FOLDER/*; do
     git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
     cd $CLONE_DIR
     find . -maxdepth 1 -type f -exec rm -iv {} \;
-    cp -r $BASE/$folder/. .
+    cp -r $BASE/$folder .
   fi
 
   # Commit if there is anything to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ for folder in $FOLDER/*; do
   # Commit if there is anything to
   if [ -n "$(git status --porcelain)" ]; then
     echo  "  Committing $REPO_NAME to $GITHUB_REPOSITORY"
+    cd ../../
     git add .
     git commit --message "Update $REPO_NAME from $GITHUB_REPOSITORY"
     git push origin $BRANCH_NAME

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ for folder in $FOLDER/*; do
     git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
     cd $CLONE_DIR
     find . -maxdepth 1 -type f -exec rm -iv {} \;
-    cp -r $BASE/$CLONE_DIR/* .
+    cp -r $BASE/$folder/. .
   fi
 
   # Commit if there is anything to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ echo "Cloning folders in $FOLDER and pushing to $GITHUB_USERNAME"
 # sync to read-only clones
 for folder in $FOLDER/*; do
   [ -d "$folder" ] || continue # only directories
+  cd $folder
+  foldername=${PWD##*/}
   cd $BASE
 
   echo "$folder"
@@ -29,14 +31,13 @@ for folder in $FOLDER/*; do
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
-  mkdir -p ./$folder
-  cp -r $BASE/$folder/. ./$folder
+  mkdir -p ./$foldername
+  cp -r $BASE/$folder/. ./$foldername
 
 
   # Commit if there is anything to
   if [ -n "$(git status --porcelain)" ]; then
     echo  "  Committing $REPO_NAME to $GITHUB_REPOSITORY"
-    cd ../../
     git add .
     git commit --message "Update $REPO_NAME from $GITHUB_REPOSITORY"
     git push origin $BRANCH_NAME

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ for folder in $FOLDER/*; do
   # this handles file deletions, additions, and changes seamlessly
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
-  [ -d $foldername ] && find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
+  [ -d $foldername ] && find ./$foldername | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
   # delete all files only in that folder if folder exists
   mkdir -p ./$foldername
   cp -r $BASE/$folder/. ./$foldername

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,7 @@ for folder in $FOLDER/*; do
     echo "  No changes, skipping $BASE/$folder/"
   fi
   
+  cd ..
   rm -r $CLONE_DIR
   cd $BASE
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ for folder in $FOLDER/*; do
     git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
     cd $CLONE_DIR
     find . -maxdepth 1 -type f -exec rm -iv {} \;
-    cp -r $BASE/* .
+    cp -r $BASE/$CLONE_DIR/* .
   fi
 
   # Commit if there is anything to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,6 @@ for folder in $FOLDER/*; do
     echo "  No changes, skipping $BASE/$folder/"
   fi
   
-  rmdir -r $CLONE_DIR
+  rm -r $CLONE_DIR
   cd $BASE
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,27 +15,43 @@ echo "Cloning folders in $FOLDER and pushing to $GITHUB_USERNAME"
 
 # sync to read-only clones
 for folder in $FOLDER/*; do
-  [ -d "$folder" ] || continue # only directories
-  cd $folder
-  foldername=${PWD##*/}
-  cd $BASE
+  if [ -d "$folder" ] # only directories
+  then
+    cd $folder
+    foldername=${PWD##*/}
+    cd $BASE
 
-  echo "$folder"
+    echo "$folder"
 
-  echo "  Name: $REPO_NAME"
-  CLONE_DIR="__${REPO_NAME}__clone__"
-  echo "  Clone dir: $CLONE_DIR"
+    echo "  Name: $REPO_NAME"
+    CLONE_DIR="__${REPO_NAME}__clone__"
+    echo "  Clone dir: $CLONE_DIR"
 
-  # clone, delete files in the clone, and copy (new) files over
-  # this handles file deletions, additions, and changes seamlessly
-  git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
-  cd $CLONE_DIR
-  [ -d $foldername ] && find ./$foldername | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
-  # delete all files only in that folder if folder exists
-  mkdir -p ./$foldername
-  cp -r $BASE/$folder/. ./$foldername
-  echo "  Copied files to $foldername"
+    # clone, delete files in the clone, and copy (new) files over
+    # this handles file deletions, additions, and changes seamlessly
+    git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
+    cd $CLONE_DIR
+    [ -d $foldername ] && find ./$foldername | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
+    # delete all files only in that folder if folder exists
+    mkdir -p ./$foldername
+    cp -r $BASE/$folder/. ./$foldername
+    echo "  Copied files to $foldername"
+    
+  else
+    cd $BASE
 
+    echo "$folder"
+
+    echo "  Name: $REPO_NAME"
+    CLONE_DIR="__${REPO_NAME}__clone__"
+    echo "  Clone dir: $CLONE_DIR"
+    echo "  Updating file: $folder"
+    
+    git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
+    cd $CLONE_DIR
+    find . -maxdepth 1 -type f -exec rm -iv {} \;
+    cp -r $BASE/. .
+  fi
 
   # Commit if there is anything to
   if [ -n "$(git status --porcelain)" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,7 @@ for folder in $FOLDER/*; do
   # this handles file deletions, additions, and changes seamlessly
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
+  ls
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   mkdir -p ./$foldername
   cp -r $BASE/$folder/. ./$foldername

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,8 @@ for folder in $FOLDER/*; do
   # this handles file deletions, additions, and changes seamlessly
   git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
   cd $CLONE_DIR
-  ls
-  find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+  [ -d $foldername ] && find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
+  # delete all files only in that folder if folder exists
   mkdir -p ./$foldername
   cp -r $BASE/$folder/. ./$foldername
   echo "  Copied files to $foldername"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ for folder in $FOLDER/*; do
     git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
     cd $CLONE_DIR
     find . -maxdepth 1 -type f -exec rm -iv {} \;
-    cp -r $BASE/. .
+    cp -r $BASE/* .
   fi
 
   # Commit if there is anything to


### PR DESCRIPTION
### 1. `entrypoint.sh` continually failed and stopped looping after one directory
Removing `&> /dev/null` from
```sh
git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/$GITHUB_USERNAME/$REPO_NAME.git $CLONE_DIR &> /dev/null
```
revealed an error. `git clone` cannot clone to an existing directory.

#### Solution
Add the statements below to remove the cloned directory after each iteration so `git clone` does not return an error.
```sh
  cd ..
  rm -r $CLONE_DIR
```

### 2. Files were not placed in individual directories and instead dumped into root directory
Example: Files from `/responses` were placed in the root directory instead of a folder named `/responses`. 

#### Solution
Obtain the directory name (ie. responses) using `foldername=${PWD##*/}`. Then create a directory with the correct name and copy the files from the clone to `/responses` instead of root directory.
```sh
    mkdir -p ./$foldername
    cp -r $BASE/$folder/. ./$foldername
```

### 3. ALL files were removed from the root directory
Example: When the `/solutions` directory was being updated, the program deleted all files within the repository - including all files in `/responses`. This resulted in a repository ONLY with the `/solutions` files.

#### Solution
Using the directory name obtained in problem #2, this statement only deletes files in the concerned directory (ie. only in `/solutions`) instead of in the entire repository.
```sh
[ -d $foldername ] && find ./$foldername | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf
```

### 4. Files were ignored
The README.md, course-details.md, and config.yml files in the root directory were all ignored because of this statement:
```sh
[ -d "$folder" ] || continue
```

#### Solution
Files and directories require different procedures, so logic was implemented depending on whether the `$folder` was a file or directory.

```sh
if [ -d "$folder" ]
then
...
else
...
fi
```
